### PR TITLE
Add image with all packages required for compilation in the qemu image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -153,3 +153,12 @@ RUN apt-get update && \
     apt-get install -y libevdev2 libsdl2-2.0-0
 
 CMD run_xochitl.sh
+
+FROM qemu-rm2fb AS qemu-dev
+
+ADD install_devtools.sh /opt
+
+RUN run_vm.sh -serial null -daemonize && \
+    wait_ssh.sh && \
+    cat /opt/install_devtools.sh | ssh root@localhost && \
+    save_vm.sh

--- a/install_devtools.sh
+++ b/install_devtools.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -eu
+
+echo "Installing basic build tools"
+opkg install gcc binutils busybox gawk ldd make sed tar
+echo "Installing recommended build tools"
+opkg install coreutils-install diffutils ldconfig patch pkg-config --force-overwrite
+echo "Installing automake, cmake, meson, and ninja"
+opkg install automake libintl-full libtool-bin cmake icu libopenssl bash git git-http python3-pip python3-setuptools coreutils-od
+python3 -m pip install -U wheel
+cd /opt/tmp
+git clone https://github.com/ninja-build/ninja.git
+cd ./ninja
+git checkout release
+CONFIG_SHELL=/opt/bin/bash python3 ./configure.py --bootstrap
+install -Dm0755 -t /opt/bin ./ninja
+cd /opt/tmp && rm -Rf /opt/tmp/ninja
+python3 -m pip install -U meson
+echo "Installing header files"
+for pkg in gcc libncurses-dev libxml2-dev python3-dev ruby-dev zlib-dev; do
+    if opkg list-installed "${pkg}"; then
+        opkg install "${pkg}" --force-overwrite --force-reinstall;
+    fi;
+done
+/opt/bin/busybox wget -qO- "$(/opt/bin/busybox sed -Ene \
+  's|^src/gz[[:space:]]entware[[:space:]]https?([[:graph:]]+)|http\1/include/include.tar.gz|p' \
+  /opt/etc/opkg.conf)" | /opt/bin/busybox tar x -vzC /opt/include

--- a/install_devtools.sh
+++ b/install_devtools.sh
@@ -2,6 +2,7 @@
 
 set -eu
 
+opkg update
 echo "Installing basic build tools"
 opkg install gcc binutils busybox gawk ldd make sed tar
 echo "Installing recommended build tools"


### PR DESCRIPTION
This would be useful for things that can't cross compile.

I've based the install steps on https://github.com/entware/entware/wiki/Using-GCC-for-native-compilation